### PR TITLE
use same triggers for app & integration tests

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,7 +1,11 @@
 name: Integration Tests
 
 on:
-    workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
     contents: read

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,6 +5,7 @@ name: Python application
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:


### PR DESCRIPTION
This is a suggestion on how to harmonize CI trigger conditions of tests run in `python-app.yml` and `integration-test`.

Currently the conditions still include a `workflow_dispatch` for manual triggering, which is not really necessary, but sometimes convenient for testing.
Also tests are run upon push to `main`, so any PR merge result should also be automatically tested this way.

In general I think it would make sense to protect `main` against accidental push if this is not the case already.

@brown170 What's your opinion on this?
